### PR TITLE
Added support for windowed PoE

### DIFF
--- a/POE_QOL2.py
+++ b/POE_QOL2.py
@@ -70,17 +70,18 @@ class MyApplication(pygubu.TkApplication):
         self.setup_app()
 
     # Detect PoE-window location
-    # Returns 
+    # Returns width, height, x-, and y-offset
     def get_poe_window_location(self):
         hwnd = windll.user32.FindWindowW(0, 'Path of Exile')
         rect = wintypes.RECT()
         windll.user32.GetWindowRect(hwnd, pointer(rect))
 
-        height_offset = 39 # Window border size
-        width_offset = 16 # Window border size
+        height_offset = 39 # Offset to get correct height
+        width_offset = 16 # -||- width
         height = rect.bottom - rect.top - height_offset
         width = rect.right - rect.left - width_offset
-        
+
+        # 7 and 31 are magical offset numbers related to Windows-border size
         return (width, height, rect.left + 7, rect.top + 31)
 
     def setup_app(self):

--- a/POE_QOL2.py
+++ b/POE_QOL2.py
@@ -12,6 +12,7 @@ from math import ceil
 from tkinter import font
 import datetime
 import pyperclip
+from ctypes import wintypes, windll, pointer
 
 def debug_app(debug_bool):
         import sys
@@ -68,8 +69,21 @@ class MyApplication(pygubu.TkApplication):
         # self.check_filter()  # This is legacy, to set the self.active_status parameter. I don't think that is needed anymore
         self.setup_app()
 
-    def setup_app(self):
+    # Detect PoE-window location
+    # Returns 
+    def get_poe_window_location(self):
+        hwnd = windll.user32.FindWindowW(0, 'Path of Exile')
+        rect = wintypes.RECT()
+        windll.user32.GetWindowRect(hwnd, pointer(rect))
 
+        height_offset = 39 # Window border size
+        width_offset = 16 # Window border size
+        height = rect.bottom - rect.top - height_offset
+        width = rect.right - rect.left - width_offset
+        
+        return (width, height, rect.left + 7, rect.top + 31)
+
+    def setup_app(self):
         """
         We run this on initialization. This is a separate method so that we can reload the settings while app is running. It *might* cause some undesired effects. TBD
         """
@@ -77,14 +91,23 @@ class MyApplication(pygubu.TkApplication):
             self.pp.pprint("Setting Up App")
         #Note to self,  from trying a bunch of different resolutions and 3 monitors i found that,
         # stash/inv tabs had a fixed width to height ratio of 886/1440 (~0.6153)that must be obeyed.
-        self.screen_res = [int(dim) for dim in self.config['Config']['screen_res'].split('x')]
-        if len(self.screen_res) != 2:
-            raise ValueError("Screen Resolution was not given correctly. Use no spaces and only a single 'x'.")
-        # self.tab_width_frac = 888/1440 * self.screen_res[1] / self.screen_res[0] # Not actually used in the end.
-        # from same experiments, stash starts 22 pixels away from edge, or 22/1440 fraction of screen width, and top is 215/1440 fraction.
-        self.tab_origin = 22/1440 * self.screen_res[1], 215/1440 * self.screen_res[1]
-        # apply similar rules to ending coordinates  -notaspy 14-9-2020
-        self.tab_end = 864/1440 * self.screen_res[1], 1057/1440 * self.screen_res[1]
+        if self.config['Config']['windowed'].lower() == 'true':
+            window_props = self.get_poe_window_location()
+            # self.tab_width_frac = 888/1440 * self.screen_res[1] / self.screen_res[0] # Not actually used in the end.
+            # from same experiments, stash starts 22 pixels away from edge, or 22/1440 fraction of screen width, and top is 215/1440 fraction.
+            self.tab_origin = window_props[2] + 22/1440 * window_props[1], window_props[3] + 215/1440 * window_props[1]
+            # apply similar rules to ending coordinates  -notaspy 14-9-2020
+            self.tab_end = window_props[2] + 864/1440 * window_props[1], window_props[3] + 1057/1440 * window_props[1]
+        else:
+            self.screen_res = [int(dim) for dim in self.config['Config']['screen_res'].split('x')]
+            if len(self.screen_res) != 2:
+                raise ValueError("Screen Resolution was not given correctly. Use no spaces and only a single 'x'.")
+            # self.tab_width_frac = 888/1440 * self.screen_res[1] / self.screen_res[0] # Not actually used in the end.
+            # from same experiments, stash starts 22 pixels away from edge, or 22/1440 fraction of screen width, and top is 215/1440 fraction.
+            self.tab_origin = 22/1440 * self.screen_res[1], 215/1440 * self.screen_res[1]
+            # apply similar rules to ending coordinates  -notaspy 14-9-2020
+            self.tab_end = 864/1440 * self.screen_res[1], 1057/1440 * self.screen_res[1]
+        
         # scale the size of a stash tab box depending on if it is quad or not.
         # TODO: currently set by user, but can actually get this from the site request
         if self.config['Config']['quad_tab'].lower() == 'true':

--- a/Setup.ini
+++ b/Setup.ini
@@ -38,8 +38,10 @@ highlight_max_num_sets=2
 #### ignore threshold for certain item slots. Usually Rings, Amulets, and Belts are limiting, so they are always show. Options are: BodyArmours,Helmets,OneHandWeapons,Gloves,Boots,Amulets,Belts,Rings
 ignore_threshold=Rings,Amulets,Belts
 
-#### Run POE in full-screen windowed on monitor 1 and input that monitors resolution below
-#screen_res=3440x1440
+#### Run POE in full-screen windowed on monitor 1 and input that monitors resolution below.
+#### If you run windowed, set windowed=True and start Path of Exile with the window size and position you want, then start poe_QOL2
+#### If you change the size or position of your Path of Exile window, restart poe_QOL2
+windowed=False
 screen_res=1920x1080
 
 #### refresh_time(below): How often, in seconds, you expect the public stash to be updated. 

--- a/Setup.ini
+++ b/Setup.ini
@@ -41,6 +41,7 @@ ignore_threshold=Rings,Amulets,Belts
 #### Run POE in full-screen windowed on monitor 1 and input that monitors resolution below.
 #### If you run windowed, set windowed=True and start Path of Exile with the window size and position you want, then start poe_QOL2
 #### If you change the size or position of your Path of Exile window, restart poe_QOL2
+#### screen_res does not matter when windowed=True
 windowed=False
 screen_res=1920x1080
 


### PR DESCRIPTION
Can now display chaos recipe-overlay for Path of Exile in windowed mode.
This is done by grabbing the location of the Path of Exile window and adding some offsets depending on the window position.
Next step would be to add some way to reload the recipe overlay-position when the user changes window size or position. Maybe rerun setup_app() when the overlay's refresh button is pressed.

Enable by setting windowed to True in Setup.ini, screen_res does not matter when windowed=True.

Works perfectly for me but may need some testing. Not tested with 1920x1080 monitor.
Guess the .exe also has to be rebuilt with this addition.